### PR TITLE
Some fixes

### DIFF
--- a/examples/auth-with-state.rs
+++ b/examples/auth-with-state.rs
@@ -34,7 +34,10 @@ async fn validate_authtoken(
         authstate.authed = Some(state.clone().lock().await.authtoken == token);
         Ok((req, resp, authstate))
     } else {
-        Err(Error::StatusCode(StatusCode::UNAUTHORIZED))
+        Err(Error::StatusCode(
+            StatusCode::UNAUTHORIZED,
+            String::default(),
+        ))
     }
 }
 
@@ -66,7 +69,10 @@ async fn hello(
         ));
     }
 
-    Err(Error::StatusCode(StatusCode::UNAUTHORIZED))
+    Err(Error::StatusCode(
+        StatusCode::UNAUTHORIZED,
+        String::default(),
+    ))
 }
 
 // Our global application state; must be `Clone`.

--- a/examples/disk-auth.rs
+++ b/examples/disk-auth.rs
@@ -12,7 +12,7 @@ async fn validate_authtoken(
 ) -> HTTPResult<NoState> {
     let token = req.headers().get("X-AuthToken");
     if token.is_none() {
-        return Err(Error::StatusCode(StatusCode::UNAUTHORIZED));
+        return Err(Error::StatusCode(StatusCode::UNAUTHORIZED, String::new()));
     }
 
     let token = token.unwrap();
@@ -26,7 +26,7 @@ async fn validate_authtoken(
     };
 
     if !matches {
-        return Err(Error::StatusCode(StatusCode::UNAUTHORIZED));
+        return Err(Error::StatusCode(StatusCode::UNAUTHORIZED, String::new()));
     }
 
     return Ok((req, resp, NoState {}));

--- a/src/app.rs
+++ b/src/app.rs
@@ -142,10 +142,10 @@ impl<S: 'static + Clone + Send, T: TransientState + 'static + Clone + Send> App<
     pub async fn dispatch(&self, req: Request<Body>) -> Result<Response<Body>, Infallible> {
         match self.router.dispatch(req, self.clone()).await {
             Ok(resp) => Ok(resp),
-            Err(e) => match e {
-                Error::StatusCode(sc) => Ok(Response::builder()
+            Err(e) => match e.clone() {
+                Error::StatusCode(sc, msg) => Ok(Response::builder()
                     .status(sc)
-                    .body(Body::default())
+                    .body(Body::from(msg))
                     .unwrap()),
                 Error::InternalServerError(e) => Ok(Response::builder()
                     .status(StatusCode::INTERNAL_SERVER_ERROR)
@@ -181,12 +181,13 @@ impl<S: 'static + Clone + Send, T: TransientState + 'static + Clone + Send> App<
     }
 }
 
-pub struct TestService<S: Clone + Send + 'static, T: TransientState + 'static + Clone + Send> {
+#[derive(Clone)]
+pub struct TestApp<S: Clone + Send + 'static, T: TransientState + 'static + Clone + Send> {
     app: App<S, T>,
     headers: Option<HeaderMap>,
 }
 
-impl<S: Clone + Send + 'static, T: TransientState + 'static + Clone + Send> TestService<S, T> {
+impl<S: Clone + Send + 'static, T: TransientState + 'static + Clone + Send> TestApp<S, T> {
     pub fn new(app: App<S, T>) -> Self {
         Self { app, headers: None }
     }

--- a/src/router.rs
+++ b/src/router.rs
@@ -52,7 +52,10 @@ impl<S: Clone + Send, T: TransientState> Route<S, T> {
         let params = self.path.extract(provided)?;
 
         if self.method != req.method() {
-            return Err(Error::StatusCode(http::StatusCode::NOT_FOUND));
+            return Err(Error::StatusCode(
+                http::StatusCode::NOT_FOUND,
+                String::new(),
+            ));
         }
 
         self.handler.perform(req, None, params, app, state).await
@@ -85,14 +88,20 @@ impl<S: Clone + Send, T: TransientState + Clone + Send> Router<S, T> {
                     .dispatch(path.to_string(), req, app, T::initial())
                     .await?;
                 if response.is_none() {
-                    return Err(Error::StatusCode(http::StatusCode::INTERNAL_SERVER_ERROR));
+                    return Err(Error::StatusCode(
+                        http::StatusCode::INTERNAL_SERVER_ERROR,
+                        String::new(),
+                    ));
                 }
 
                 return Ok(response.unwrap());
             }
         }
 
-        Err(Error::StatusCode(http::StatusCode::NOT_FOUND))
+        Err(Error::StatusCode(
+            http::StatusCode::METHOD_NOT_ALLOWED,
+            String::new(),
+        ))
     }
 }
 


### PR DESCRIPTION
- StatusCode error types now take a string for the body.
- Route failures return METHOD_NOT_ALLOWED, which I should double check
  but is more accurate.

Signed-off-by: Erik Hollensbe <linux@hollensbe.org>